### PR TITLE
Allow jira auto-linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,6 +2,8 @@
 
 https://solidarityco.atlassian.net/browse/TICKET-####
 
+https://solidarityco.atlassian.net/browse/TICKET-####
+
 **PR Dependencies:** N/A
 
 ## Description

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,6 @@
-## [TICKET-#](https://solidarityco.atlassian.net/browse/TICKET-#)
+## External Context
+
+https://solidarityco.atlassian.net/browse/TICKET-#
 
 **PR Dependencies:** N/A
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## External Context
 
-https://solidarityco.atlassian.net/browse/TICKET-#
+https://solidarityco.atlassian.net/browse/TICKET-####
 
 **PR Dependencies:** N/A
 


### PR DESCRIPTION
## Motivation and Context

The way we add jira ticket links in PR templates isn't actually being picked up by jira. That's why I've been adding them to the PR title, which is picked up by Jira. Example => https://github.com/SolidarityCompany/lightrail/pull/413

Linking the jira tickets in this new manner allows them to be picked up by the Github <=> Jira integration, which makes them get automatically linked on the jira tickets themselves. Example screenshot from => https://solidarityco.atlassian.net/browse/BLUE-1130

![image](https://user-images.githubusercontent.com/5768468/92499135-5c1a7f80-f1b0-11ea-8134-d100a738a316.png)

## External Context

I also mention this in slack here https://bluelinkdata.slack.com/archives/C3XME44N5/p1599579829008700

## Future Followup

I'm here because I would like to add "workflow triggers" to Jira. Those will make it so that issues are automatically marked as "in progress" if they get linked in a Github PR